### PR TITLE
PHP 8.1 support.

### DIFF
--- a/src/Auth/Model/AuthLoginRequest.php
+++ b/src/Auth/Model/AuthLoginRequest.php
@@ -295,6 +295,7 @@ class AuthLoginRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class AuthLoginRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class AuthLoginRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class AuthLoginRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Auth/Model/AuthLoginResponse.php
+++ b/src/Auth/Model/AuthLoginResponse.php
@@ -355,6 +355,7 @@ class AuthLoginResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class AuthLoginResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class AuthLoginResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class AuthLoginResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Auth/Model/AuthLoginResponseData.php
+++ b/src/Auth/Model/AuthLoginResponseData.php
@@ -265,6 +265,7 @@ class AuthLoginResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class AuthLoginResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class AuthLoginResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class AuthLoginResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Auth/Model/ErrorError.php
+++ b/src/Auth/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Auth/Model/ErrorWarning.php
+++ b/src/Auth/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Auth/Model/SpamExpertGenerateLoginURLRequest.php
+++ b/src/Auth/Model/SpamExpertGenerateLoginURLRequest.php
@@ -265,6 +265,7 @@ class SpamExpertGenerateLoginURLRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class SpamExpertGenerateLoginURLRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class SpamExpertGenerateLoginURLRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class SpamExpertGenerateLoginURLRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Auth/Model/SpamExpertGenerateLoginURLResponse.php
+++ b/src/Auth/Model/SpamExpertGenerateLoginURLResponse.php
@@ -355,6 +355,7 @@ class SpamExpertGenerateLoginURLResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class SpamExpertGenerateLoginURLResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class SpamExpertGenerateLoginURLResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class SpamExpertGenerateLoginURLResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Auth/Model/SpamExpertGenerateLoginURLResponseData.php
+++ b/src/Auth/Model/SpamExpertGenerateLoginURLResponseData.php
@@ -235,6 +235,7 @@ class SpamExpertGenerateLoginURLResponseData implements ModelInterface, ArrayAcc
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class SpamExpertGenerateLoginURLResponseData implements ModelInterface, ArrayAcc
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class SpamExpertGenerateLoginURLResponseData implements ModelInterface, ArrayAcc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class SpamExpertGenerateLoginURLResponseData implements ModelInterface, ArrayAcc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/ErrorError.php
+++ b/src/Billing/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/ErrorWarning.php
+++ b/src/Billing/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/InvoiceInvoice.php
+++ b/src/Billing/Model/InvoiceInvoice.php
@@ -385,6 +385,7 @@ class InvoiceInvoice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class InvoiceInvoice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class InvoiceInvoice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class InvoiceInvoice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/InvoiceListInvoicesResponse.php
+++ b/src/Billing/Model/InvoiceListInvoicesResponse.php
@@ -355,6 +355,7 @@ class InvoiceListInvoicesResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class InvoiceListInvoicesResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class InvoiceListInvoicesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class InvoiceListInvoicesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/InvoiceListInvoicesResponseData.php
+++ b/src/Billing/Model/InvoiceListInvoicesResponseData.php
@@ -265,6 +265,7 @@ class InvoiceListInvoicesResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class InvoiceListInvoicesResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class InvoiceListInvoicesResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class InvoiceListInvoicesResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/InvoicePrice.php
+++ b/src/Billing/Model/InvoicePrice.php
@@ -265,6 +265,7 @@ class InvoicePrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class InvoicePrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class InvoicePrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class InvoicePrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/InvoicePrices.php
+++ b/src/Billing/Model/InvoicePrices.php
@@ -265,6 +265,7 @@ class InvoicePrices implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class InvoicePrices implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class InvoicePrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class InvoicePrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/PaymentListPaymentsResponse.php
+++ b/src/Billing/Model/PaymentListPaymentsResponse.php
@@ -355,6 +355,7 @@ class PaymentListPaymentsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class PaymentListPaymentsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class PaymentListPaymentsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class PaymentListPaymentsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/PaymentListPaymentsResponseData.php
+++ b/src/Billing/Model/PaymentListPaymentsResponseData.php
@@ -265,6 +265,7 @@ class PaymentListPaymentsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class PaymentListPaymentsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class PaymentListPaymentsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class PaymentListPaymentsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/PaymentListPaymentsResponseDataResults.php
+++ b/src/Billing/Model/PaymentListPaymentsResponseDataResults.php
@@ -475,6 +475,7 @@ class PaymentListPaymentsResponseDataResults implements ModelInterface, ArrayAcc
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -487,6 +488,7 @@ class PaymentListPaymentsResponseDataResults implements ModelInterface, ArrayAcc
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -500,6 +502,7 @@ class PaymentListPaymentsResponseDataResults implements ModelInterface, ArrayAcc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -516,6 +519,7 @@ class PaymentListPaymentsResponseDataResults implements ModelInterface, ArrayAcc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/PaymentPrice.php
+++ b/src/Billing/Model/PaymentPrice.php
@@ -265,6 +265,7 @@ class PaymentPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class PaymentPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class PaymentPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class PaymentPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/PaymentPrices.php
+++ b/src/Billing/Model/PaymentPrices.php
@@ -265,6 +265,7 @@ class PaymentPrices implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class PaymentPrices implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class PaymentPrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class PaymentPrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/TransactionListTransactionsResponse.php
+++ b/src/Billing/Model/TransactionListTransactionsResponse.php
@@ -355,6 +355,7 @@ class TransactionListTransactionsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class TransactionListTransactionsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class TransactionListTransactionsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class TransactionListTransactionsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/TransactionListTransactionsResponseData.php
+++ b/src/Billing/Model/TransactionListTransactionsResponseData.php
@@ -265,6 +265,7 @@ class TransactionListTransactionsResponseData implements ModelInterface, ArrayAc
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TransactionListTransactionsResponseData implements ModelInterface, ArrayAc
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TransactionListTransactionsResponseData implements ModelInterface, ArrayAc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TransactionListTransactionsResponseData implements ModelInterface, ArrayAc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/TransactionListTransactionsResponseDataResults.php
+++ b/src/Billing/Model/TransactionListTransactionsResponseDataResults.php
@@ -595,6 +595,7 @@ class TransactionListTransactionsResponseDataResults implements ModelInterface, 
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -607,6 +608,7 @@ class TransactionListTransactionsResponseDataResults implements ModelInterface, 
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -620,6 +622,7 @@ class TransactionListTransactionsResponseDataResults implements ModelInterface, 
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -636,6 +639,7 @@ class TransactionListTransactionsResponseDataResults implements ModelInterface, 
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/TransactionPrice.php
+++ b/src/Billing/Model/TransactionPrice.php
@@ -265,6 +265,7 @@ class TransactionPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TransactionPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TransactionPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TransactionPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Billing/Model/TransactionPrices.php
+++ b/src/Billing/Model/TransactionPrices.php
@@ -265,6 +265,7 @@ class TransactionPrices implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TransactionPrices implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TransactionPrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TransactionPrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ErrorError.php
+++ b/src/Dns/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ErrorWarning.php
+++ b/src/Dns/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/HistoryZoneHistory.php
+++ b/src/Dns/Model/HistoryZoneHistory.php
@@ -325,6 +325,7 @@ class HistoryZoneHistory implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class HistoryZoneHistory implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class HistoryZoneHistory implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class HistoryZoneHistory implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NameserverCreateNameserverResponse.php
+++ b/src/Dns/Model/NameserverCreateNameserverResponse.php
@@ -355,6 +355,7 @@ class NameserverCreateNameserverResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class NameserverCreateNameserverResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class NameserverCreateNameserverResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class NameserverCreateNameserverResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NameserverGetNameserverResponse.php
+++ b/src/Dns/Model/NameserverGetNameserverResponse.php
@@ -355,6 +355,7 @@ class NameserverGetNameserverResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class NameserverGetNameserverResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class NameserverGetNameserverResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class NameserverGetNameserverResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NameserverListNameserversResponse.php
+++ b/src/Dns/Model/NameserverListNameserversResponse.php
@@ -355,6 +355,7 @@ class NameserverListNameserversResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class NameserverListNameserversResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class NameserverListNameserversResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class NameserverListNameserversResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NameserverListNameserversResponseData.php
+++ b/src/Dns/Model/NameserverListNameserversResponseData.php
@@ -265,6 +265,7 @@ class NameserverListNameserversResponseData implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class NameserverListNameserversResponseData implements ModelInterface, ArrayAcce
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class NameserverListNameserversResponseData implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class NameserverListNameserversResponseData implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NameserverNameserver.php
+++ b/src/Dns/Model/NameserverNameserver.php
@@ -295,6 +295,7 @@ class NameserverNameserver implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class NameserverNameserver implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class NameserverNameserver implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class NameserverNameserver implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NameserverNameserverBoolResponse.php
+++ b/src/Dns/Model/NameserverNameserverBoolResponse.php
@@ -355,6 +355,7 @@ class NameserverNameserverBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class NameserverNameserverBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class NameserverNameserverBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class NameserverNameserverBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NameserverNameserverBoolResponseData.php
+++ b/src/Dns/Model/NameserverNameserverBoolResponseData.php
@@ -235,6 +235,7 @@ class NameserverNameserverBoolResponseData implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class NameserverNameserverBoolResponseData implements ModelInterface, ArrayAcces
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class NameserverNameserverBoolResponseData implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class NameserverNameserverBoolResponseData implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupCreateGroupRequest.php
+++ b/src/Dns/Model/NsGroupCreateGroupRequest.php
@@ -265,6 +265,7 @@ class NsGroupCreateGroupRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class NsGroupCreateGroupRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class NsGroupCreateGroupRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class NsGroupCreateGroupRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupCreateGroupResponse.php
+++ b/src/Dns/Model/NsGroupCreateGroupResponse.php
@@ -355,6 +355,7 @@ class NsGroupCreateGroupResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class NsGroupCreateGroupResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class NsGroupCreateGroupResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class NsGroupCreateGroupResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupGetGroupResponse.php
+++ b/src/Dns/Model/NsGroupGetGroupResponse.php
@@ -355,6 +355,7 @@ class NsGroupGetGroupResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class NsGroupGetGroupResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class NsGroupGetGroupResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class NsGroupGetGroupResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupGroup.php
+++ b/src/Dns/Model/NsGroupGroup.php
@@ -355,6 +355,7 @@ class NsGroupGroup implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class NsGroupGroup implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class NsGroupGroup implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class NsGroupGroup implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupGroupBoolResponse.php
+++ b/src/Dns/Model/NsGroupGroupBoolResponse.php
@@ -355,6 +355,7 @@ class NsGroupGroupBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class NsGroupGroupBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class NsGroupGroupBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class NsGroupGroupBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupGroupBoolResponseData.php
+++ b/src/Dns/Model/NsGroupGroupBoolResponseData.php
@@ -235,6 +235,7 @@ class NsGroupGroupBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class NsGroupGroupBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class NsGroupGroupBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class NsGroupGroupBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupListGroupsOrderBy.php
+++ b/src/Dns/Model/NsGroupListGroupsOrderBy.php
@@ -295,6 +295,7 @@ class NsGroupListGroupsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class NsGroupListGroupsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class NsGroupListGroupsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class NsGroupListGroupsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupListGroupsResponse.php
+++ b/src/Dns/Model/NsGroupListGroupsResponse.php
@@ -355,6 +355,7 @@ class NsGroupListGroupsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class NsGroupListGroupsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class NsGroupListGroupsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class NsGroupListGroupsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupListGroupsResponseData.php
+++ b/src/Dns/Model/NsGroupListGroupsResponseData.php
@@ -265,6 +265,7 @@ class NsGroupListGroupsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class NsGroupListGroupsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class NsGroupListGroupsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class NsGroupListGroupsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupNameServersSet.php
+++ b/src/Dns/Model/NsGroupNameServersSet.php
@@ -355,6 +355,7 @@ class NsGroupNameServersSet implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class NsGroupNameServersSet implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class NsGroupNameServersSet implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class NsGroupNameServersSet implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/NsGroupUpdateGroupRequest.php
+++ b/src/Dns/Model/NsGroupUpdateGroupRequest.php
@@ -265,6 +265,7 @@ class NsGroupUpdateGroupRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class NsGroupUpdateGroupRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class NsGroupUpdateGroupRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class NsGroupUpdateGroupRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/RecordListZoneRecordsOrderBy.php
+++ b/src/Dns/Model/RecordListZoneRecordsOrderBy.php
@@ -355,6 +355,7 @@ class RecordListZoneRecordsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class RecordListZoneRecordsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class RecordListZoneRecordsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class RecordListZoneRecordsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/RecordListZoneRecordsResponse.php
+++ b/src/Dns/Model/RecordListZoneRecordsResponse.php
@@ -355,6 +355,7 @@ class RecordListZoneRecordsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class RecordListZoneRecordsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class RecordListZoneRecordsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class RecordListZoneRecordsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/RecordListZoneRecordsResponseData.php
+++ b/src/Dns/Model/RecordListZoneRecordsResponseData.php
@@ -265,6 +265,7 @@ class RecordListZoneRecordsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class RecordListZoneRecordsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class RecordListZoneRecordsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class RecordListZoneRecordsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/RecordRecordInfo.php
+++ b/src/Dns/Model/RecordRecordInfo.php
@@ -445,6 +445,7 @@ class RecordRecordInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -457,6 +458,7 @@ class RecordRecordInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -470,6 +472,7 @@ class RecordRecordInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -486,6 +489,7 @@ class RecordRecordInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/TemplateCreateTemplateRequest.php
+++ b/src/Dns/Model/TemplateCreateTemplateRequest.php
@@ -295,6 +295,7 @@ class TemplateCreateTemplateRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class TemplateCreateTemplateRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class TemplateCreateTemplateRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class TemplateCreateTemplateRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/TemplateCreateTemplateResponse.php
+++ b/src/Dns/Model/TemplateCreateTemplateResponse.php
@@ -355,6 +355,7 @@ class TemplateCreateTemplateResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class TemplateCreateTemplateResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class TemplateCreateTemplateResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class TemplateCreateTemplateResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/TemplateCreateTemplateResponseData.php
+++ b/src/Dns/Model/TemplateCreateTemplateResponseData.php
@@ -235,6 +235,7 @@ class TemplateCreateTemplateResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class TemplateCreateTemplateResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class TemplateCreateTemplateResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class TemplateCreateTemplateResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/TemplateGetTemplateResponse.php
+++ b/src/Dns/Model/TemplateGetTemplateResponse.php
@@ -355,6 +355,7 @@ class TemplateGetTemplateResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class TemplateGetTemplateResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class TemplateGetTemplateResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class TemplateGetTemplateResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/TemplateListTemplatesResponse.php
+++ b/src/Dns/Model/TemplateListTemplatesResponse.php
@@ -355,6 +355,7 @@ class TemplateListTemplatesResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class TemplateListTemplatesResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class TemplateListTemplatesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class TemplateListTemplatesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/TemplateListTemplatesResponseData.php
+++ b/src/Dns/Model/TemplateListTemplatesResponseData.php
@@ -265,6 +265,7 @@ class TemplateListTemplatesResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TemplateListTemplatesResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TemplateListTemplatesResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TemplateListTemplatesResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/TemplateRecord.php
+++ b/src/Dns/Model/TemplateRecord.php
@@ -385,6 +385,7 @@ class TemplateRecord implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class TemplateRecord implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class TemplateRecord implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class TemplateRecord implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/TemplateTemplate.php
+++ b/src/Dns/Model/TemplateTemplate.php
@@ -325,6 +325,7 @@ class TemplateTemplate implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class TemplateTemplate implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class TemplateTemplate implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class TemplateTemplate implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/TemplateTemplateBoolResponse.php
+++ b/src/Dns/Model/TemplateTemplateBoolResponse.php
@@ -355,6 +355,7 @@ class TemplateTemplateBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class TemplateTemplateBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class TemplateTemplateBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class TemplateTemplateBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/TemplateTemplateBoolResponseData.php
+++ b/src/Dns/Model/TemplateTemplateBoolResponseData.php
@@ -235,6 +235,7 @@ class TemplateTemplateBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class TemplateTemplateBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class TemplateTemplateBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class TemplateTemplateBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneCreateZoneRequest.php
+++ b/src/Dns/Model/ZoneCreateZoneRequest.php
@@ -445,6 +445,7 @@ class ZoneCreateZoneRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -457,6 +458,7 @@ class ZoneCreateZoneRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -470,6 +472,7 @@ class ZoneCreateZoneRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -486,6 +489,7 @@ class ZoneCreateZoneRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneDomain.php
+++ b/src/Dns/Model/ZoneDomain.php
@@ -265,6 +265,7 @@ class ZoneDomain implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ZoneDomain implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ZoneDomain implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ZoneDomain implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneGetZoneResponse.php
+++ b/src/Dns/Model/ZoneGetZoneResponse.php
@@ -355,6 +355,7 @@ class ZoneGetZoneResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ZoneGetZoneResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ZoneGetZoneResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ZoneGetZoneResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneListZonesOrderBy.php
+++ b/src/Dns/Model/ZoneListZonesOrderBy.php
@@ -295,6 +295,7 @@ class ZoneListZonesOrderBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ZoneListZonesOrderBy implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ZoneListZonesOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ZoneListZonesOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneListZonesResponse.php
+++ b/src/Dns/Model/ZoneListZonesResponse.php
@@ -355,6 +355,7 @@ class ZoneListZonesResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ZoneListZonesResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ZoneListZonesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ZoneListZonesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneListZonesResponseData.php
+++ b/src/Dns/Model/ZoneListZonesResponseData.php
@@ -265,6 +265,7 @@ class ZoneListZonesResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ZoneListZonesResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ZoneListZonesResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ZoneListZonesResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZonePremiumDnsData.php
+++ b/src/Dns/Model/ZonePremiumDnsData.php
@@ -235,6 +235,7 @@ class ZonePremiumDnsData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ZonePremiumDnsData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ZonePremiumDnsData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ZonePremiumDnsData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneRecord.php
+++ b/src/Dns/Model/ZoneRecord.php
@@ -355,6 +355,7 @@ class ZoneRecord implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ZoneRecord implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ZoneRecord implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ZoneRecord implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneRecordUpdates.php
+++ b/src/Dns/Model/ZoneRecordUpdates.php
@@ -325,6 +325,7 @@ class ZoneRecordUpdates implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class ZoneRecordUpdates implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class ZoneRecordUpdates implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class ZoneRecordUpdates implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneRecordWithOriginal.php
+++ b/src/Dns/Model/ZoneRecordWithOriginal.php
@@ -265,6 +265,7 @@ class ZoneRecordWithOriginal implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ZoneRecordWithOriginal implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ZoneRecordWithOriginal implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ZoneRecordWithOriginal implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneSectigoData.php
+++ b/src/Dns/Model/ZoneSectigoData.php
@@ -355,6 +355,7 @@ class ZoneSectigoData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ZoneSectigoData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ZoneSectigoData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ZoneSectigoData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneUpdateZoneRequest.php
+++ b/src/Dns/Model/ZoneUpdateZoneRequest.php
@@ -475,6 +475,7 @@ class ZoneUpdateZoneRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -487,6 +488,7 @@ class ZoneUpdateZoneRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -500,6 +502,7 @@ class ZoneUpdateZoneRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -516,6 +519,7 @@ class ZoneUpdateZoneRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneZone.php
+++ b/src/Dns/Model/ZoneZone.php
@@ -685,6 +685,7 @@ class ZoneZone implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -697,6 +698,7 @@ class ZoneZone implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -710,6 +712,7 @@ class ZoneZone implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -726,6 +729,7 @@ class ZoneZone implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneZoneBoolResponse.php
+++ b/src/Dns/Model/ZoneZoneBoolResponse.php
@@ -355,6 +355,7 @@ class ZoneZoneBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ZoneZoneBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ZoneZoneBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ZoneZoneBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Dns/Model/ZoneZoneBoolResponseData.php
+++ b/src/Dns/Model/ZoneZoneBoolResponseData.php
@@ -235,6 +235,7 @@ class ZoneZoneBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ZoneZoneBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ZoneZoneBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ZoneZoneBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/AdditionalDataGetAdditionalDataResponse.php
+++ b/src/Domain/Model/AdditionalDataGetAdditionalDataResponse.php
@@ -355,6 +355,7 @@ class AdditionalDataGetAdditionalDataResponse implements ModelInterface, ArrayAc
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class AdditionalDataGetAdditionalDataResponse implements ModelInterface, ArrayAc
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class AdditionalDataGetAdditionalDataResponse implements ModelInterface, ArrayAc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class AdditionalDataGetAdditionalDataResponse implements ModelInterface, ArrayAc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/AdditionalDataSelectOption.php
+++ b/src/Domain/Model/AdditionalDataSelectOption.php
@@ -265,6 +265,7 @@ class AdditionalDataSelectOption implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class AdditionalDataSelectOption implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class AdditionalDataSelectOption implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class AdditionalDataSelectOption implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/AdditionalDataSpecification.php
+++ b/src/Domain/Model/AdditionalDataSpecification.php
@@ -355,6 +355,7 @@ class AdditionalDataSpecification implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class AdditionalDataSpecification implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class AdditionalDataSpecification implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class AdditionalDataSpecification implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/AuthcodeAuthInfo.php
+++ b/src/Domain/Model/AuthcodeAuthInfo.php
@@ -235,6 +235,7 @@ class AuthcodeAuthInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class AuthcodeAuthInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class AuthcodeAuthInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class AuthcodeAuthInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/AuthcodeGetAuthCodeResponse.php
+++ b/src/Domain/Model/AuthcodeGetAuthCodeResponse.php
@@ -355,6 +355,7 @@ class AuthcodeGetAuthCodeResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class AuthcodeGetAuthCodeResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class AuthcodeGetAuthCodeResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class AuthcodeGetAuthCodeResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/AuthcodeGetAuthCodeResponseData.php
+++ b/src/Domain/Model/AuthcodeGetAuthCodeResponseData.php
@@ -295,6 +295,7 @@ class AuthcodeGetAuthCodeResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class AuthcodeGetAuthCodeResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class AuthcodeGetAuthCodeResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class AuthcodeGetAuthCodeResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/AuthcodeResetAuthCodeRequest.php
+++ b/src/Domain/Model/AuthcodeResetAuthCodeRequest.php
@@ -325,6 +325,7 @@ class AuthcodeResetAuthCodeRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class AuthcodeResetAuthCodeRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class AuthcodeResetAuthCodeRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class AuthcodeResetAuthCodeRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/AuthcodeResetAuthCodeResponse.php
+++ b/src/Domain/Model/AuthcodeResetAuthCodeResponse.php
@@ -355,6 +355,7 @@ class AuthcodeResetAuthCodeResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class AuthcodeResetAuthCodeResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class AuthcodeResetAuthCodeResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class AuthcodeResetAuthCodeResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/AuthcodeResetAuthCodeResponseData.php
+++ b/src/Domain/Model/AuthcodeResetAuthCodeResponseData.php
@@ -415,6 +415,7 @@ class AuthcodeResetAuthCodeResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -427,6 +428,7 @@ class AuthcodeResetAuthCodeResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -440,6 +442,7 @@ class AuthcodeResetAuthCodeResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -456,6 +459,7 @@ class AuthcodeResetAuthCodeResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/AuthcodeRgpStatuses.php
+++ b/src/Domain/Model/AuthcodeRgpStatuses.php
@@ -265,6 +265,7 @@ class AuthcodeRgpStatuses implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class AuthcodeRgpStatuses implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class AuthcodeRgpStatuses implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class AuthcodeRgpStatuses implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/CustomerGetDataResponse.php
+++ b/src/Domain/Model/CustomerGetDataResponse.php
@@ -355,6 +355,7 @@ class CustomerGetDataResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class CustomerGetDataResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class CustomerGetDataResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class CustomerGetDataResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainAbuseDetails.php
+++ b/src/Domain/Model/DomainAbuseDetails.php
@@ -295,6 +295,7 @@ class DomainAbuseDetails implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class DomainAbuseDetails implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class DomainAbuseDetails implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class DomainAbuseDetails implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainAdditionalData.php
+++ b/src/Domain/Model/DomainAdditionalData.php
@@ -1345,6 +1345,7 @@ class DomainAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1357,6 +1358,7 @@ class DomainAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -1370,6 +1372,7 @@ class DomainAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1386,6 +1389,7 @@ class DomainAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainApiHistory.php
+++ b/src/Domain/Model/DomainApiHistory.php
@@ -355,6 +355,7 @@ class DomainApiHistory implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainApiHistory implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainApiHistory implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainApiHistory implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainApproveTransferRequest.php
+++ b/src/Domain/Model/DomainApproveTransferRequest.php
@@ -355,6 +355,7 @@ class DomainApproveTransferRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainApproveTransferRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainApproveTransferRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainApproveTransferRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainCheckAdditionalData.php
+++ b/src/Domain/Model/DomainCheckAdditionalData.php
@@ -235,6 +235,7 @@ class DomainCheckAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class DomainCheckAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class DomainCheckAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class DomainCheckAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainCheckDomainRequest.php
+++ b/src/Domain/Model/DomainCheckDomainRequest.php
@@ -325,6 +325,7 @@ class DomainCheckDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class DomainCheckDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class DomainCheckDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class DomainCheckDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainCheckDomainResponse.php
+++ b/src/Domain/Model/DomainCheckDomainResponse.php
@@ -355,6 +355,7 @@ class DomainCheckDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainCheckDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainCheckDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainCheckDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainCheckDomainResponseData.php
+++ b/src/Domain/Model/DomainCheckDomainResponseData.php
@@ -235,6 +235,7 @@ class DomainCheckDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class DomainCheckDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class DomainCheckDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class DomainCheckDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainCheckDomainResult.php
+++ b/src/Domain/Model/DomainCheckDomainResult.php
@@ -445,6 +445,7 @@ class DomainCheckDomainResult implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -457,6 +458,7 @@ class DomainCheckDomainResult implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -470,6 +472,7 @@ class DomainCheckDomainResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -486,6 +489,7 @@ class DomainCheckDomainResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainCreateDomainRequest.php
+++ b/src/Domain/Model/DomainCreateDomainRequest.php
@@ -1045,6 +1045,7 @@ class DomainCreateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1057,6 +1058,7 @@ class DomainCreateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -1070,6 +1072,7 @@ class DomainCreateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1086,6 +1089,7 @@ class DomainCreateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainCreateDomainResponse.php
+++ b/src/Domain/Model/DomainCreateDomainResponse.php
@@ -355,6 +355,7 @@ class DomainCreateDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainCreateDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainCreateDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainCreateDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainCreateDomainResponseData.php
+++ b/src/Domain/Model/DomainCreateDomainResponseData.php
@@ -415,6 +415,7 @@ class DomainCreateDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -427,6 +428,7 @@ class DomainCreateDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -440,6 +442,7 @@ class DomainCreateDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -456,6 +459,7 @@ class DomainCreateDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainDeleteDomainResponse.php
+++ b/src/Domain/Model/DomainDeleteDomainResponse.php
@@ -355,6 +355,7 @@ class DomainDeleteDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainDeleteDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainDeleteDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainDeleteDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainDeleteDomainResponseData.php
+++ b/src/Domain/Model/DomainDeleteDomainResponseData.php
@@ -235,6 +235,7 @@ class DomainDeleteDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class DomainDeleteDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class DomainDeleteDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class DomainDeleteDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainDnssecKey.php
+++ b/src/Domain/Model/DomainDnssecKey.php
@@ -355,6 +355,7 @@ class DomainDnssecKey implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainDnssecKey implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainDnssecKey implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainDnssecKey implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainDomain.php
+++ b/src/Domain/Model/DomainDomain.php
@@ -265,6 +265,7 @@ class DomainDomain implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainDomain implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainDomain implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainDomain implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainGetDomainResponse.php
+++ b/src/Domain/Model/DomainGetDomainResponse.php
@@ -355,6 +355,7 @@ class DomainGetDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainGetDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainGetDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainGetDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainGetDomainResponseData.php
+++ b/src/Domain/Model/DomainGetDomainResponseData.php
@@ -2575,6 +2575,7 @@ class DomainGetDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -2587,6 +2588,7 @@ class DomainGetDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -2600,6 +2602,7 @@ class DomainGetDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -2616,6 +2619,7 @@ class DomainGetDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainHistory.php
+++ b/src/Domain/Model/DomainHistory.php
@@ -385,6 +385,7 @@ class DomainHistory implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class DomainHistory implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class DomainHistory implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class DomainHistory implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainListDomainsRequestOrderBy.php
+++ b/src/Domain/Model/DomainListDomainsRequestOrderBy.php
@@ -475,6 +475,7 @@ class DomainListDomainsRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -487,6 +488,7 @@ class DomainListDomainsRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -500,6 +502,7 @@ class DomainListDomainsRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -516,6 +519,7 @@ class DomainListDomainsRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainListDomainsRequestResponseField.php
+++ b/src/Domain/Model/DomainListDomainsRequestResponseField.php
@@ -265,6 +265,7 @@ class DomainListDomainsRequestResponseField implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainListDomainsRequestResponseField implements ModelInterface, ArrayAcce
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainListDomainsRequestResponseField implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainListDomainsRequestResponseField implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainListDomainsResponse.php
+++ b/src/Domain/Model/DomainListDomainsResponse.php
@@ -355,6 +355,7 @@ class DomainListDomainsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainListDomainsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainListDomainsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainListDomainsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainListDomainsResponseData.php
+++ b/src/Domain/Model/DomainListDomainsResponseData.php
@@ -265,6 +265,7 @@ class DomainListDomainsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainListDomainsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainListDomainsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainListDomainsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainNameserver.php
+++ b/src/Domain/Model/DomainNameserver.php
@@ -325,6 +325,7 @@ class DomainNameserver implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class DomainNameserver implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class DomainNameserver implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class DomainNameserver implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainOperationPrice.php
+++ b/src/Domain/Model/DomainOperationPrice.php
@@ -235,6 +235,7 @@ class DomainOperationPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class DomainOperationPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class DomainOperationPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class DomainOperationPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainOwner.php
+++ b/src/Domain/Model/DomainOwner.php
@@ -265,6 +265,7 @@ class DomainOwner implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainOwner implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainOwner implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainOwner implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainPremiumPrice.php
+++ b/src/Domain/Model/DomainPremiumPrice.php
@@ -265,6 +265,7 @@ class DomainPremiumPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainPremiumPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainPremiumPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainPremiumPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainPrice.php
+++ b/src/Domain/Model/DomainPrice.php
@@ -265,6 +265,7 @@ class DomainPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainPriceGroup.php
+++ b/src/Domain/Model/DomainPriceGroup.php
@@ -265,6 +265,7 @@ class DomainPriceGroup implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainPriceGroup implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainPriceGroup implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainPriceGroup implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainRegistryStatus.php
+++ b/src/Domain/Model/DomainRegistryStatus.php
@@ -265,6 +265,7 @@ class DomainRegistryStatus implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainRegistryStatus implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainRegistryStatus implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainRegistryStatus implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainRegistryStatuses.php
+++ b/src/Domain/Model/DomainRegistryStatuses.php
@@ -265,6 +265,7 @@ class DomainRegistryStatuses implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainRegistryStatuses implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainRegistryStatuses implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainRegistryStatuses implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainRenewDomainRequest.php
+++ b/src/Domain/Model/DomainRenewDomainRequest.php
@@ -295,6 +295,7 @@ class DomainRenewDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class DomainRenewDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class DomainRenewDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class DomainRenewDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainRenewDomainResponse.php
+++ b/src/Domain/Model/DomainRenewDomainResponse.php
@@ -355,6 +355,7 @@ class DomainRenewDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainRenewDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainRenewDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainRenewDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainRenewDomainResponseData.php
+++ b/src/Domain/Model/DomainRenewDomainResponseData.php
@@ -235,6 +235,7 @@ class DomainRenewDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class DomainRenewDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class DomainRenewDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class DomainRenewDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainRestoreDomainRequest.php
+++ b/src/Domain/Model/DomainRestoreDomainRequest.php
@@ -265,6 +265,7 @@ class DomainRestoreDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainRestoreDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainRestoreDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainRestoreDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainRestoreDomainResponse.php
+++ b/src/Domain/Model/DomainRestoreDomainResponse.php
@@ -355,6 +355,7 @@ class DomainRestoreDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainRestoreDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainRestoreDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainRestoreDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainRestoreDomainResponseData.php
+++ b/src/Domain/Model/DomainRestoreDomainResponseData.php
@@ -235,6 +235,7 @@ class DomainRestoreDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class DomainRestoreDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class DomainRestoreDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class DomainRestoreDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainSendFoa1Request.php
+++ b/src/Domain/Model/DomainSendFoa1Request.php
@@ -265,6 +265,7 @@ class DomainSendFoa1Request implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainSendFoa1Request implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainSendFoa1Request implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainSendFoa1Request implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainSuggestNameDomainRequest.php
+++ b/src/Domain/Model/DomainSuggestNameDomainRequest.php
@@ -385,6 +385,7 @@ class DomainSuggestNameDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class DomainSuggestNameDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class DomainSuggestNameDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class DomainSuggestNameDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainSuggestNameDomainResponse.php
+++ b/src/Domain/Model/DomainSuggestNameDomainResponse.php
@@ -355,6 +355,7 @@ class DomainSuggestNameDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainSuggestNameDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainSuggestNameDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainSuggestNameDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainSuggestNameDomainResponseData.php
+++ b/src/Domain/Model/DomainSuggestNameDomainResponseData.php
@@ -235,6 +235,7 @@ class DomainSuggestNameDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class DomainSuggestNameDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class DomainSuggestNameDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class DomainSuggestNameDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainSuggestNameDomainResult.php
+++ b/src/Domain/Model/DomainSuggestNameDomainResult.php
@@ -295,6 +295,7 @@ class DomainSuggestNameDomainResult implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class DomainSuggestNameDomainResult implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class DomainSuggestNameDomainResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class DomainSuggestNameDomainResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainTradeDomainRequest.php
+++ b/src/Domain/Model/DomainTradeDomainRequest.php
@@ -715,6 +715,7 @@ class DomainTradeDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -727,6 +728,7 @@ class DomainTradeDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -740,6 +742,7 @@ class DomainTradeDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -756,6 +759,7 @@ class DomainTradeDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainTradeDomainResponse.php
+++ b/src/Domain/Model/DomainTradeDomainResponse.php
@@ -355,6 +355,7 @@ class DomainTradeDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainTradeDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainTradeDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainTradeDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainTradeDomainResponseData.php
+++ b/src/Domain/Model/DomainTradeDomainResponseData.php
@@ -325,6 +325,7 @@ class DomainTradeDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class DomainTradeDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class DomainTradeDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class DomainTradeDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainTransferAdditionalData.php
+++ b/src/Domain/Model/DomainTransferAdditionalData.php
@@ -805,6 +805,7 @@ class DomainTransferAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -817,6 +818,7 @@ class DomainTransferAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -830,6 +832,7 @@ class DomainTransferAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -846,6 +849,7 @@ class DomainTransferAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainTransferDomainRequest.php
+++ b/src/Domain/Model/DomainTransferDomainRequest.php
@@ -895,6 +895,7 @@ class DomainTransferDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -907,6 +908,7 @@ class DomainTransferDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -920,6 +922,7 @@ class DomainTransferDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -936,6 +939,7 @@ class DomainTransferDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainTransferDomainResponse.php
+++ b/src/Domain/Model/DomainTransferDomainResponse.php
@@ -355,6 +355,7 @@ class DomainTransferDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainTransferDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainTransferDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainTransferDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainTransferDomainResponseData.php
+++ b/src/Domain/Model/DomainTransferDomainResponseData.php
@@ -505,6 +505,7 @@ class DomainTransferDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -517,6 +518,7 @@ class DomainTransferDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -530,6 +532,7 @@ class DomainTransferDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -546,6 +549,7 @@ class DomainTransferDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainTryAgainLastOperationRequest.php
+++ b/src/Domain/Model/DomainTryAgainLastOperationRequest.php
@@ -295,6 +295,7 @@ class DomainTryAgainLastOperationRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class DomainTryAgainLastOperationRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class DomainTryAgainLastOperationRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class DomainTryAgainLastOperationRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainUINDocumentType.php
+++ b/src/Domain/Model/DomainUINDocumentType.php
@@ -265,6 +265,7 @@ class DomainUINDocumentType implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainUINDocumentType implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainUINDocumentType implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainUINDocumentType implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainUpdateAdditionalData.php
+++ b/src/Domain/Model/DomainUpdateAdditionalData.php
@@ -715,6 +715,7 @@ class DomainUpdateAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -727,6 +728,7 @@ class DomainUpdateAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -740,6 +742,7 @@ class DomainUpdateAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -756,6 +759,7 @@ class DomainUpdateAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainUpdateDomainRequest.php
+++ b/src/Domain/Model/DomainUpdateDomainRequest.php
@@ -1015,6 +1015,7 @@ class DomainUpdateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1027,6 +1028,7 @@ class DomainUpdateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -1040,6 +1042,7 @@ class DomainUpdateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1056,6 +1059,7 @@ class DomainUpdateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainUpdateDomainResponse.php
+++ b/src/Domain/Model/DomainUpdateDomainResponse.php
@@ -355,6 +355,7 @@ class DomainUpdateDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class DomainUpdateDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class DomainUpdateDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class DomainUpdateDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainUpdateDomainResponseData.php
+++ b/src/Domain/Model/DomainUpdateDomainResponseData.php
@@ -265,6 +265,7 @@ class DomainUpdateDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class DomainUpdateDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class DomainUpdateDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class DomainUpdateDomainResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/DomainWhoisPrivacyData.php
+++ b/src/Domain/Model/DomainWhoisPrivacyData.php
@@ -235,6 +235,7 @@ class DomainWhoisPrivacyData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class DomainWhoisPrivacyData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class DomainWhoisPrivacyData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class DomainWhoisPrivacyData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/ErrorError.php
+++ b/src/Domain/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/ErrorWarning.php
+++ b/src/Domain/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/PriceGetPriceResponse.php
+++ b/src/Domain/Model/PriceGetPriceResponse.php
@@ -355,6 +355,7 @@ class PriceGetPriceResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class PriceGetPriceResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class PriceGetPriceResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class PriceGetPriceResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/PriceGetPriceResponseData.php
+++ b/src/Domain/Model/PriceGetPriceResponseData.php
@@ -385,6 +385,7 @@ class PriceGetPriceResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class PriceGetPriceResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class PriceGetPriceResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class PriceGetPriceResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/PricePromotionData.php
+++ b/src/Domain/Model/PricePromotionData.php
@@ -265,6 +265,7 @@ class PricePromotionData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class PricePromotionData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class PricePromotionData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class PricePromotionData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/ResponseBoolResponse.php
+++ b/src/Domain/Model/ResponseBoolResponse.php
@@ -355,6 +355,7 @@ class ResponseBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ResponseBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ResponseBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ResponseBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Domain/Model/ResponseBoolResponseData.php
+++ b/src/Domain/Model/ResponseBoolResponseData.php
@@ -235,6 +235,7 @@ class ResponseBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ResponseBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ResponseBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ResponseBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailCreateEmailRequest.php
+++ b/src/EmailTemplate/Model/EmailCreateEmailRequest.php
@@ -415,6 +415,7 @@ class EmailCreateEmailRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -427,6 +428,7 @@ class EmailCreateEmailRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -440,6 +442,7 @@ class EmailCreateEmailRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -456,6 +459,7 @@ class EmailCreateEmailRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailCreateEmailResponse.php
+++ b/src/EmailTemplate/Model/EmailCreateEmailResponse.php
@@ -355,6 +355,7 @@ class EmailCreateEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class EmailCreateEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class EmailCreateEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class EmailCreateEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailCreateEmailResponseData.php
+++ b/src/EmailTemplate/Model/EmailCreateEmailResponseData.php
@@ -235,6 +235,7 @@ class EmailCreateEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class EmailCreateEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class EmailCreateEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class EmailCreateEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailDeleteEmailResponse.php
+++ b/src/EmailTemplate/Model/EmailDeleteEmailResponse.php
@@ -355,6 +355,7 @@ class EmailDeleteEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class EmailDeleteEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class EmailDeleteEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class EmailDeleteEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailDeleteEmailResponseData.php
+++ b/src/EmailTemplate/Model/EmailDeleteEmailResponseData.php
@@ -235,6 +235,7 @@ class EmailDeleteEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class EmailDeleteEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class EmailDeleteEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class EmailDeleteEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailFields.php
+++ b/src/EmailTemplate/Model/EmailFields.php
@@ -265,6 +265,7 @@ class EmailFields implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class EmailFields implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class EmailFields implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class EmailFields implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailListEmailsResponse.php
+++ b/src/EmailTemplate/Model/EmailListEmailsResponse.php
@@ -355,6 +355,7 @@ class EmailListEmailsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class EmailListEmailsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class EmailListEmailsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class EmailListEmailsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailListEmailsResponseData.php
+++ b/src/EmailTemplate/Model/EmailListEmailsResponseData.php
@@ -265,6 +265,7 @@ class EmailListEmailsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class EmailListEmailsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class EmailListEmailsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class EmailListEmailsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailListEmailsResponseDataResults.php
+++ b/src/EmailTemplate/Model/EmailListEmailsResponseDataResults.php
@@ -445,6 +445,7 @@ class EmailListEmailsResponseDataResults implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -457,6 +458,7 @@ class EmailListEmailsResponseDataResults implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -470,6 +472,7 @@ class EmailListEmailsResponseDataResults implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -486,6 +489,7 @@ class EmailListEmailsResponseDataResults implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailTags.php
+++ b/src/EmailTemplate/Model/EmailTags.php
@@ -265,6 +265,7 @@ class EmailTags implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class EmailTags implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class EmailTags implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class EmailTags implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailUpdateEmailRequest.php
+++ b/src/EmailTemplate/Model/EmailUpdateEmailRequest.php
@@ -445,6 +445,7 @@ class EmailUpdateEmailRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -457,6 +458,7 @@ class EmailUpdateEmailRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -470,6 +472,7 @@ class EmailUpdateEmailRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -486,6 +489,7 @@ class EmailUpdateEmailRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailUpdateEmailResponse.php
+++ b/src/EmailTemplate/Model/EmailUpdateEmailResponse.php
@@ -355,6 +355,7 @@ class EmailUpdateEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class EmailUpdateEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class EmailUpdateEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class EmailUpdateEmailResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/EmailUpdateEmailResponseData.php
+++ b/src/EmailTemplate/Model/EmailUpdateEmailResponseData.php
@@ -235,6 +235,7 @@ class EmailUpdateEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class EmailUpdateEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class EmailUpdateEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class EmailUpdateEmailResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/ErrorError.php
+++ b/src/EmailTemplate/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/EmailTemplate/Model/ErrorWarning.php
+++ b/src/EmailTemplate/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Helpers/Model/ErrorError.php
+++ b/src/Helpers/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Helpers/Model/ErrorWarning.php
+++ b/src/Helpers/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Helpers/Model/HelperstagTag.php
+++ b/src/Helpers/Model/HelperstagTag.php
@@ -265,6 +265,7 @@ class HelperstagTag implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class HelperstagTag implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class HelperstagTag implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class HelperstagTag implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Helpers/Model/TagCreateTagResponse.php
+++ b/src/Helpers/Model/TagCreateTagResponse.php
@@ -355,6 +355,7 @@ class TagCreateTagResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class TagCreateTagResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class TagCreateTagResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class TagCreateTagResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Helpers/Model/TagCreateTagResponseData.php
+++ b/src/Helpers/Model/TagCreateTagResponseData.php
@@ -235,6 +235,7 @@ class TagCreateTagResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class TagCreateTagResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class TagCreateTagResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class TagCreateTagResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Helpers/Model/TagDeleteTagResponse.php
+++ b/src/Helpers/Model/TagDeleteTagResponse.php
@@ -355,6 +355,7 @@ class TagDeleteTagResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class TagDeleteTagResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class TagDeleteTagResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class TagDeleteTagResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Helpers/Model/TagDeleteTagResponseData.php
+++ b/src/Helpers/Model/TagDeleteTagResponseData.php
@@ -235,6 +235,7 @@ class TagDeleteTagResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class TagDeleteTagResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class TagDeleteTagResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class TagDeleteTagResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Helpers/Model/TagListTagsResponse.php
+++ b/src/Helpers/Model/TagListTagsResponse.php
@@ -355,6 +355,7 @@ class TagListTagsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class TagListTagsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class TagListTagsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class TagListTagsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Helpers/Model/TagListTagsResponseData.php
+++ b/src/Helpers/Model/TagListTagsResponseData.php
@@ -265,6 +265,7 @@ class TagListTagsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TagListTagsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TagListTagsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TagListTagsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/ErrorError.php
+++ b/src/License/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/ErrorWarning.php
+++ b/src/License/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseCreateLicenseResponseData.php
+++ b/src/License/Model/LicenseCreateLicenseResponseData.php
@@ -265,6 +265,7 @@ class LicenseCreateLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class LicenseCreateLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class LicenseCreateLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class LicenseCreateLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseCreatePleskLicenseRequest.php
+++ b/src/License/Model/LicenseCreatePleskLicenseRequest.php
@@ -445,6 +445,7 @@ class LicenseCreatePleskLicenseRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -457,6 +458,7 @@ class LicenseCreatePleskLicenseRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -470,6 +472,7 @@ class LicenseCreatePleskLicenseRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -486,6 +489,7 @@ class LicenseCreatePleskLicenseRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseCreatePleskLicenseResponse.php
+++ b/src/License/Model/LicenseCreatePleskLicenseResponse.php
@@ -355,6 +355,7 @@ class LicenseCreatePleskLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class LicenseCreatePleskLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class LicenseCreatePleskLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class LicenseCreatePleskLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseCreateVirtuozzoLicenseRequest.php
+++ b/src/License/Model/LicenseCreateVirtuozzoLicenseRequest.php
@@ -475,6 +475,7 @@ class LicenseCreateVirtuozzoLicenseRequest implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -487,6 +488,7 @@ class LicenseCreateVirtuozzoLicenseRequest implements ModelInterface, ArrayAcces
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -500,6 +502,7 @@ class LicenseCreateVirtuozzoLicenseRequest implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -516,6 +519,7 @@ class LicenseCreateVirtuozzoLicenseRequest implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseCreateVirtuozzoLicenseResponse.php
+++ b/src/License/Model/LicenseCreateVirtuozzoLicenseResponse.php
@@ -355,6 +355,7 @@ class LicenseCreateVirtuozzoLicenseResponse implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class LicenseCreateVirtuozzoLicenseResponse implements ModelInterface, ArrayAcce
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class LicenseCreateVirtuozzoLicenseResponse implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class LicenseCreateVirtuozzoLicenseResponse implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseDeleteLicenseResponse.php
+++ b/src/License/Model/LicenseDeleteLicenseResponse.php
@@ -355,6 +355,7 @@ class LicenseDeleteLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class LicenseDeleteLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class LicenseDeleteLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class LicenseDeleteLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseDeleteLicenseResponseData.php
+++ b/src/License/Model/LicenseDeleteLicenseResponseData.php
@@ -235,6 +235,7 @@ class LicenseDeleteLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class LicenseDeleteLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class LicenseDeleteLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class LicenseDeleteLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseExtendedLicense.php
+++ b/src/License/Model/LicenseExtendedLicense.php
@@ -775,6 +775,7 @@ class LicenseExtendedLicense implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -787,6 +788,7 @@ class LicenseExtendedLicense implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -800,6 +802,7 @@ class LicenseExtendedLicense implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -816,6 +819,7 @@ class LicenseExtendedLicense implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseGetLicenseKeyResponse.php
+++ b/src/License/Model/LicenseGetLicenseKeyResponse.php
@@ -355,6 +355,7 @@ class LicenseGetLicenseKeyResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class LicenseGetLicenseKeyResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class LicenseGetLicenseKeyResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class LicenseGetLicenseKeyResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseGetLicenseResponse.php
+++ b/src/License/Model/LicenseGetLicenseResponse.php
@@ -355,6 +355,7 @@ class LicenseGetLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class LicenseGetLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class LicenseGetLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class LicenseGetLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseKey.php
+++ b/src/License/Model/LicenseKey.php
@@ -325,6 +325,7 @@ class LicenseKey implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class LicenseKey implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class LicenseKey implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class LicenseKey implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseLicenseItem.php
+++ b/src/License/Model/LicenseLicenseItem.php
@@ -325,6 +325,7 @@ class LicenseLicenseItem implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class LicenseLicenseItem implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class LicenseLicenseItem implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class LicenseLicenseItem implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseLicenseKey.php
+++ b/src/License/Model/LicenseLicenseKey.php
@@ -235,6 +235,7 @@ class LicenseLicenseKey implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class LicenseLicenseKey implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class LicenseLicenseKey implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class LicenseLicenseKey implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseLicenseWithPriceVersion.php
+++ b/src/License/Model/LicenseLicenseWithPriceVersion.php
@@ -655,6 +655,7 @@ class LicenseLicenseWithPriceVersion implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -667,6 +668,7 @@ class LicenseLicenseWithPriceVersion implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -680,6 +682,7 @@ class LicenseLicenseWithPriceVersion implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -696,6 +699,7 @@ class LicenseLicenseWithPriceVersion implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseListItemsOrderBy.php
+++ b/src/License/Model/LicenseListItemsOrderBy.php
@@ -415,6 +415,7 @@ class LicenseListItemsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -427,6 +428,7 @@ class LicenseListItemsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -440,6 +442,7 @@ class LicenseListItemsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -456,6 +459,7 @@ class LicenseListItemsOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseListItemsResponse.php
+++ b/src/License/Model/LicenseListItemsResponse.php
@@ -355,6 +355,7 @@ class LicenseListItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class LicenseListItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class LicenseListItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class LicenseListItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseListItemsResponseData.php
+++ b/src/License/Model/LicenseListItemsResponseData.php
@@ -265,6 +265,7 @@ class LicenseListItemsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class LicenseListItemsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class LicenseListItemsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class LicenseListItemsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseListLicensesOrderBy.php
+++ b/src/License/Model/LicenseListLicensesOrderBy.php
@@ -415,6 +415,7 @@ class LicenseListLicensesOrderBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -427,6 +428,7 @@ class LicenseListLicensesOrderBy implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -440,6 +442,7 @@ class LicenseListLicensesOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -456,6 +459,7 @@ class LicenseListLicensesOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseListLicensesResponse.php
+++ b/src/License/Model/LicenseListLicensesResponse.php
@@ -355,6 +355,7 @@ class LicenseListLicensesResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class LicenseListLicensesResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class LicenseListLicensesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class LicenseListLicensesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseListLicensesResponseData.php
+++ b/src/License/Model/LicenseListLicensesResponseData.php
@@ -265,6 +265,7 @@ class LicenseListLicensesResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class LicenseListLicensesResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class LicenseListLicensesResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class LicenseListLicensesResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseListLicensesWithPriceVersionResponse.php
+++ b/src/License/Model/LicenseListLicensesWithPriceVersionResponse.php
@@ -355,6 +355,7 @@ class LicenseListLicensesWithPriceVersionResponse implements ModelInterface, Arr
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class LicenseListLicensesWithPriceVersionResponse implements ModelInterface, Arr
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class LicenseListLicensesWithPriceVersionResponse implements ModelInterface, Arr
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class LicenseListLicensesWithPriceVersionResponse implements ModelInterface, Arr
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseListLicensesWithPriceVersionResponseData.php
+++ b/src/License/Model/LicenseListLicensesWithPriceVersionResponseData.php
@@ -265,6 +265,7 @@ class LicenseListLicensesWithPriceVersionResponseData implements ModelInterface,
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class LicenseListLicensesWithPriceVersionResponseData implements ModelInterface,
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class LicenseListLicensesWithPriceVersionResponseData implements ModelInterface,
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class LicenseListLicensesWithPriceVersionResponseData implements ModelInterface,
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseResetHwidRequest.php
+++ b/src/License/Model/LicenseResetHwidRequest.php
@@ -265,6 +265,7 @@ class LicenseResetHwidRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class LicenseResetHwidRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class LicenseResetHwidRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class LicenseResetHwidRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseResetHwidResponse.php
+++ b/src/License/Model/LicenseResetHwidResponse.php
@@ -355,6 +355,7 @@ class LicenseResetHwidResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class LicenseResetHwidResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class LicenseResetHwidResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class LicenseResetHwidResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseResetHwidResponseData.php
+++ b/src/License/Model/LicenseResetHwidResponseData.php
@@ -235,6 +235,7 @@ class LicenseResetHwidResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class LicenseResetHwidResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class LicenseResetHwidResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class LicenseResetHwidResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseUpdateLicenseResponse.php
+++ b/src/License/Model/LicenseUpdateLicenseResponse.php
@@ -355,6 +355,7 @@ class LicenseUpdateLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class LicenseUpdateLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class LicenseUpdateLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class LicenseUpdateLicenseResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseUpdateLicenseResponseData.php
+++ b/src/License/Model/LicenseUpdateLicenseResponseData.php
@@ -235,6 +235,7 @@ class LicenseUpdateLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class LicenseUpdateLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class LicenseUpdateLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class LicenseUpdateLicenseResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseUpdatePleskLicenseRequest.php
+++ b/src/License/Model/LicenseUpdatePleskLicenseRequest.php
@@ -505,6 +505,7 @@ class LicenseUpdatePleskLicenseRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -517,6 +518,7 @@ class LicenseUpdatePleskLicenseRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -530,6 +532,7 @@ class LicenseUpdatePleskLicenseRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -546,6 +549,7 @@ class LicenseUpdatePleskLicenseRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenseUpdateVirtuozzoLicenseRequest.php
+++ b/src/License/Model/LicenseUpdateVirtuozzoLicenseRequest.php
@@ -535,6 +535,7 @@ class LicenseUpdateVirtuozzoLicenseRequest implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -547,6 +548,7 @@ class LicenseUpdateVirtuozzoLicenseRequest implements ModelInterface, ArrayAcces
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -560,6 +562,7 @@ class LicenseUpdateVirtuozzoLicenseRequest implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -576,6 +579,7 @@ class LicenseUpdateVirtuozzoLicenseRequest implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/License/Model/LicenselicenseLicense.php
+++ b/src/License/Model/LicenselicenseLicense.php
@@ -685,6 +685,7 @@ class LicenselicenseLicense implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -697,6 +698,7 @@ class LicenselicenseLicense implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -710,6 +712,7 @@ class LicenselicenseLicense implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -726,6 +729,7 @@ class LicenselicenseLicense implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactAdditionalData.php
+++ b/src/Person/Model/ContactAdditionalData.php
@@ -295,6 +295,7 @@ class ContactAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ContactAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ContactAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ContactAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactAddress.php
+++ b/src/Person/Model/ContactAddress.php
@@ -415,6 +415,7 @@ class ContactAddress implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -427,6 +428,7 @@ class ContactAddress implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -440,6 +442,7 @@ class ContactAddress implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -456,6 +459,7 @@ class ContactAddress implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactClientIpList.php
+++ b/src/Person/Model/ContactClientIpList.php
@@ -265,6 +265,7 @@ class ContactClientIpList implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ContactClientIpList implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ContactClientIpList implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ContactClientIpList implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactCreateContactRequest.php
+++ b/src/Person/Model/ContactCreateContactRequest.php
@@ -685,6 +685,7 @@ class ContactCreateContactRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -697,6 +698,7 @@ class ContactCreateContactRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -710,6 +712,7 @@ class ContactCreateContactRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -726,6 +729,7 @@ class ContactCreateContactRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactCreateContactResponse.php
+++ b/src/Person/Model/ContactCreateContactResponse.php
@@ -355,6 +355,7 @@ class ContactCreateContactResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ContactCreateContactResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ContactCreateContactResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ContactCreateContactResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactCreateContactResponseData.php
+++ b/src/Person/Model/ContactCreateContactResponseData.php
@@ -265,6 +265,7 @@ class ContactCreateContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ContactCreateContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ContactCreateContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ContactCreateContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactDeleteContactResponse.php
+++ b/src/Person/Model/ContactDeleteContactResponse.php
@@ -355,6 +355,7 @@ class ContactDeleteContactResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ContactDeleteContactResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ContactDeleteContactResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ContactDeleteContactResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactDeleteContactResponseData.php
+++ b/src/Person/Model/ContactDeleteContactResponseData.php
@@ -235,6 +235,7 @@ class ContactDeleteContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ContactDeleteContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ContactDeleteContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ContactDeleteContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactGetContactResponse.php
+++ b/src/Person/Model/ContactGetContactResponse.php
@@ -355,6 +355,7 @@ class ContactGetContactResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ContactGetContactResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ContactGetContactResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ContactGetContactResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactListContactsResponse.php
+++ b/src/Person/Model/ContactListContactsResponse.php
@@ -355,6 +355,7 @@ class ContactListContactsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ContactListContactsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ContactListContactsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ContactListContactsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactListContactsResponseData.php
+++ b/src/Person/Model/ContactListContactsResponseData.php
@@ -265,6 +265,7 @@ class ContactListContactsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ContactListContactsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ContactListContactsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ContactListContactsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactName.php
+++ b/src/Person/Model/ContactName.php
@@ -355,6 +355,7 @@ class ContactName implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ContactName implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ContactName implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ContactName implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactPhone.php
+++ b/src/Person/Model/ContactPhone.php
@@ -295,6 +295,7 @@ class ContactPhone implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ContactPhone implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ContactPhone implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ContactPhone implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactUpdateContactRequest.php
+++ b/src/Person/Model/ContactUpdateContactRequest.php
@@ -805,6 +805,7 @@ class ContactUpdateContactRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -817,6 +818,7 @@ class ContactUpdateContactRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -830,6 +832,7 @@ class ContactUpdateContactRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -846,6 +849,7 @@ class ContactUpdateContactRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactUpdateContactResponse.php
+++ b/src/Person/Model/ContactUpdateContactResponse.php
@@ -355,6 +355,7 @@ class ContactUpdateContactResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ContactUpdateContactResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ContactUpdateContactResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ContactUpdateContactResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ContactUpdateContactResponseData.php
+++ b/src/Person/Model/ContactUpdateContactResponseData.php
@@ -235,6 +235,7 @@ class ContactUpdateContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ContactUpdateContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ContactUpdateContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ContactUpdateContactResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerCreateCustomerRequest.php
+++ b/src/Person/Model/CustomerCreateCustomerRequest.php
@@ -565,6 +565,7 @@ class CustomerCreateCustomerRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -577,6 +578,7 @@ class CustomerCreateCustomerRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -590,6 +592,7 @@ class CustomerCreateCustomerRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -606,6 +609,7 @@ class CustomerCreateCustomerRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerCreateCustomerResponse.php
+++ b/src/Person/Model/CustomerCreateCustomerResponse.php
@@ -355,6 +355,7 @@ class CustomerCreateCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class CustomerCreateCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class CustomerCreateCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class CustomerCreateCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerCreateCustomerResponseData.php
+++ b/src/Person/Model/CustomerCreateCustomerResponseData.php
@@ -235,6 +235,7 @@ class CustomerCreateCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class CustomerCreateCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class CustomerCreateCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class CustomerCreateCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerCustomerAdditionalData.php
+++ b/src/Person/Model/CustomerCustomerAdditionalData.php
@@ -775,6 +775,7 @@ class CustomerCustomerAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -787,6 +788,7 @@ class CustomerCustomerAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -800,6 +802,7 @@ class CustomerCustomerAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -816,6 +819,7 @@ class CustomerCustomerAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerDeleteCustomerResponse.php
+++ b/src/Person/Model/CustomerDeleteCustomerResponse.php
@@ -355,6 +355,7 @@ class CustomerDeleteCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class CustomerDeleteCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class CustomerDeleteCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class CustomerDeleteCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerDeleteCustomerResponseData.php
+++ b/src/Person/Model/CustomerDeleteCustomerResponseData.php
@@ -235,6 +235,7 @@ class CustomerDeleteCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class CustomerDeleteCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class CustomerDeleteCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class CustomerDeleteCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerExtensionAdditionalData.php
+++ b/src/Person/Model/CustomerExtensionAdditionalData.php
@@ -265,6 +265,7 @@ class CustomerExtensionAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class CustomerExtensionAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class CustomerExtensionAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class CustomerExtensionAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerExtensionData.php
+++ b/src/Person/Model/CustomerExtensionData.php
@@ -1315,6 +1315,7 @@ class CustomerExtensionData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1327,6 +1328,7 @@ class CustomerExtensionData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -1340,6 +1342,7 @@ class CustomerExtensionData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1356,6 +1359,7 @@ class CustomerExtensionData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerFax.php
+++ b/src/Person/Model/CustomerFax.php
@@ -295,6 +295,7 @@ class CustomerFax implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class CustomerFax implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class CustomerFax implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class CustomerFax implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerFile.php
+++ b/src/Person/Model/CustomerFile.php
@@ -295,6 +295,7 @@ class CustomerFile implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class CustomerFile implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class CustomerFile implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class CustomerFile implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerGetCustomerResponse.php
+++ b/src/Person/Model/CustomerGetCustomerResponse.php
@@ -355,6 +355,7 @@ class CustomerGetCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class CustomerGetCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class CustomerGetCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class CustomerGetCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerGetCustomerResponseData.php
+++ b/src/Person/Model/CustomerGetCustomerResponseData.php
@@ -805,6 +805,7 @@ class CustomerGetCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -817,6 +818,7 @@ class CustomerGetCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -830,6 +832,7 @@ class CustomerGetCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -846,6 +849,7 @@ class CustomerGetCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerListCustomersResponse.php
+++ b/src/Person/Model/CustomerListCustomersResponse.php
@@ -355,6 +355,7 @@ class CustomerListCustomersResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class CustomerListCustomersResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class CustomerListCustomersResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class CustomerListCustomersResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerListCustomersResponseData.php
+++ b/src/Person/Model/CustomerListCustomersResponseData.php
@@ -265,6 +265,7 @@ class CustomerListCustomersResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class CustomerListCustomersResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class CustomerListCustomersResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class CustomerListCustomersResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerListCustomersResponseDataResults.php
+++ b/src/Person/Model/CustomerListCustomersResponseDataResults.php
@@ -715,6 +715,7 @@ class CustomerListCustomersResponseDataResults implements ModelInterface, ArrayA
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -727,6 +728,7 @@ class CustomerListCustomersResponseDataResults implements ModelInterface, ArrayA
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -740,6 +742,7 @@ class CustomerListCustomersResponseDataResults implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -756,6 +759,7 @@ class CustomerListCustomersResponseDataResults implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerTags.php
+++ b/src/Person/Model/CustomerTags.php
@@ -265,6 +265,7 @@ class CustomerTags implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class CustomerTags implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class CustomerTags implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class CustomerTags implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerUpdateCustomerRequest.php
+++ b/src/Person/Model/CustomerUpdateCustomerRequest.php
@@ -535,6 +535,7 @@ class CustomerUpdateCustomerRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -547,6 +548,7 @@ class CustomerUpdateCustomerRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -560,6 +562,7 @@ class CustomerUpdateCustomerRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -576,6 +579,7 @@ class CustomerUpdateCustomerRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerUpdateCustomerResponse.php
+++ b/src/Person/Model/CustomerUpdateCustomerResponse.php
@@ -355,6 +355,7 @@ class CustomerUpdateCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class CustomerUpdateCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class CustomerUpdateCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class CustomerUpdateCustomerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/CustomerUpdateCustomerResponseData.php
+++ b/src/Person/Model/CustomerUpdateCustomerResponseData.php
@@ -235,6 +235,7 @@ class CustomerUpdateCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class CustomerUpdateCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class CustomerUpdateCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class CustomerUpdateCustomerResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/EmailDomainEmailVerification.php
+++ b/src/Person/Model/EmailDomainEmailVerification.php
@@ -415,6 +415,7 @@ class EmailDomainEmailVerification implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -427,6 +428,7 @@ class EmailDomainEmailVerification implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -440,6 +442,7 @@ class EmailDomainEmailVerification implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -456,6 +459,7 @@ class EmailDomainEmailVerification implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/EmailListDomainVerificationsResponse.php
+++ b/src/Person/Model/EmailListDomainVerificationsResponse.php
@@ -355,6 +355,7 @@ class EmailListDomainVerificationsResponse implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class EmailListDomainVerificationsResponse implements ModelInterface, ArrayAcces
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class EmailListDomainVerificationsResponse implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class EmailListDomainVerificationsResponse implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/EmailListDomainVerificationsResponseData.php
+++ b/src/Person/Model/EmailListDomainVerificationsResponseData.php
@@ -265,6 +265,7 @@ class EmailListDomainVerificationsResponseData implements ModelInterface, ArrayA
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class EmailListDomainVerificationsResponseData implements ModelInterface, ArrayA
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class EmailListDomainVerificationsResponseData implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class EmailListDomainVerificationsResponseData implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/EmailRestartEmailVerificationRequest.php
+++ b/src/Person/Model/EmailRestartEmailVerificationRequest.php
@@ -295,6 +295,7 @@ class EmailRestartEmailVerificationRequest implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class EmailRestartEmailVerificationRequest implements ModelInterface, ArrayAcces
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class EmailRestartEmailVerificationRequest implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class EmailRestartEmailVerificationRequest implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/EmailRestartEmailVerificationResponse.php
+++ b/src/Person/Model/EmailRestartEmailVerificationResponse.php
@@ -355,6 +355,7 @@ class EmailRestartEmailVerificationResponse implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class EmailRestartEmailVerificationResponse implements ModelInterface, ArrayAcce
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class EmailRestartEmailVerificationResponse implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class EmailRestartEmailVerificationResponse implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/EmailRestartEmailVerificationResponseData.php
+++ b/src/Person/Model/EmailRestartEmailVerificationResponseData.php
@@ -235,6 +235,7 @@ class EmailRestartEmailVerificationResponseData implements ModelInterface, Array
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class EmailRestartEmailVerificationResponseData implements ModelInterface, Array
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class EmailRestartEmailVerificationResponseData implements ModelInterface, Array
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class EmailRestartEmailVerificationResponseData implements ModelInterface, Array
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/EmailStartEmailVerificationRequest.php
+++ b/src/Person/Model/EmailStartEmailVerificationRequest.php
@@ -325,6 +325,7 @@ class EmailStartEmailVerificationRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class EmailStartEmailVerificationRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class EmailStartEmailVerificationRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class EmailStartEmailVerificationRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/EmailStartEmailVerificationResponse.php
+++ b/src/Person/Model/EmailStartEmailVerificationResponse.php
@@ -355,6 +355,7 @@ class EmailStartEmailVerificationResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class EmailStartEmailVerificationResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class EmailStartEmailVerificationResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class EmailStartEmailVerificationResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/EmailStartEmailVerificationResponseData.php
+++ b/src/Person/Model/EmailStartEmailVerificationResponseData.php
@@ -235,6 +235,7 @@ class EmailStartEmailVerificationResponseData implements ModelInterface, ArrayAc
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class EmailStartEmailVerificationResponseData implements ModelInterface, ArrayAc
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class EmailStartEmailVerificationResponseData implements ModelInterface, ArrayAc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class EmailStartEmailVerificationResponseData implements ModelInterface, ArrayAc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/EmailVerificationRecipient.php
+++ b/src/Person/Model/EmailVerificationRecipient.php
@@ -265,6 +265,7 @@ class EmailVerificationRecipient implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class EmailVerificationRecipient implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class EmailVerificationRecipient implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class EmailVerificationRecipient implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ErrorError.php
+++ b/src/Person/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ErrorWarning.php
+++ b/src/Person/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/PersoncontactContact.php
+++ b/src/Person/Model/PersoncontactContact.php
@@ -925,6 +925,7 @@ class PersoncontactContact implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -937,6 +938,7 @@ class PersoncontactContact implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -950,6 +952,7 @@ class PersoncontactContact implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -966,6 +969,7 @@ class PersoncontactContact implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/PromoMessageListPromoMessagesResponse.php
+++ b/src/Person/Model/PromoMessageListPromoMessagesResponse.php
@@ -355,6 +355,7 @@ class PromoMessageListPromoMessagesResponse implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class PromoMessageListPromoMessagesResponse implements ModelInterface, ArrayAcce
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class PromoMessageListPromoMessagesResponse implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class PromoMessageListPromoMessagesResponse implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/PromoMessageListPromoMessagesResponseData.php
+++ b/src/Person/Model/PromoMessageListPromoMessagesResponseData.php
@@ -265,6 +265,7 @@ class PromoMessageListPromoMessagesResponseData implements ModelInterface, Array
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class PromoMessageListPromoMessagesResponseData implements ModelInterface, Array
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class PromoMessageListPromoMessagesResponseData implements ModelInterface, Array
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class PromoMessageListPromoMessagesResponseData implements ModelInterface, Array
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/PromoMessagePromoMessage.php
+++ b/src/Person/Model/PromoMessagePromoMessage.php
@@ -295,6 +295,7 @@ class PromoMessagePromoMessage implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class PromoMessagePromoMessage implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class PromoMessagePromoMessage implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class PromoMessagePromoMessage implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ResellerGetResellerResponse.php
+++ b/src/Person/Model/ResellerGetResellerResponse.php
@@ -355,6 +355,7 @@ class ResellerGetResellerResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ResellerGetResellerResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ResellerGetResellerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ResellerGetResellerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ResellerReseller.php
+++ b/src/Person/Model/ResellerReseller.php
@@ -775,6 +775,7 @@ class ResellerReseller implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -787,6 +788,7 @@ class ResellerReseller implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -800,6 +802,7 @@ class ResellerReseller implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -816,6 +819,7 @@ class ResellerReseller implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ResellerResellerAdditionalData.php
+++ b/src/Person/Model/ResellerResellerAdditionalData.php
@@ -295,6 +295,7 @@ class ResellerResellerAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ResellerResellerAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ResellerResellerAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ResellerResellerAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ResellerSettings.php
+++ b/src/Person/Model/ResellerSettings.php
@@ -1405,6 +1405,7 @@ class ResellerSettings implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1417,6 +1418,7 @@ class ResellerSettings implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -1430,6 +1432,7 @@ class ResellerSettings implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1446,6 +1449,7 @@ class ResellerSettings implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ResellerStatistics.php
+++ b/src/Person/Model/ResellerStatistics.php
@@ -445,6 +445,7 @@ class ResellerStatistics implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -457,6 +458,7 @@ class ResellerStatistics implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -470,6 +472,7 @@ class ResellerStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -486,6 +489,7 @@ class ResellerStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ResellerUpdateResellerRequest.php
+++ b/src/Person/Model/ResellerUpdateResellerRequest.php
@@ -565,6 +565,7 @@ class ResellerUpdateResellerRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -577,6 +578,7 @@ class ResellerUpdateResellerRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -590,6 +592,7 @@ class ResellerUpdateResellerRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -606,6 +609,7 @@ class ResellerUpdateResellerRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ResellerUpdateResellerResponse.php
+++ b/src/Person/Model/ResellerUpdateResellerResponse.php
@@ -355,6 +355,7 @@ class ResellerUpdateResellerResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ResellerUpdateResellerResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ResellerUpdateResellerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ResellerUpdateResellerResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/ResellerUpdateResellerResponseData.php
+++ b/src/Person/Model/ResellerUpdateResellerResponseData.php
@@ -235,6 +235,7 @@ class ResellerUpdateResellerResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ResellerUpdateResellerResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ResellerUpdateResellerResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ResellerUpdateResellerResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/SettingsGetSettingsResponse.php
+++ b/src/Person/Model/SettingsGetSettingsResponse.php
@@ -355,6 +355,7 @@ class SettingsGetSettingsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class SettingsGetSettingsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class SettingsGetSettingsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class SettingsGetSettingsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/SettingsGetSettingsResponseData.php
+++ b/src/Person/Model/SettingsGetSettingsResponseData.php
@@ -1435,6 +1435,7 @@ class SettingsGetSettingsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1447,6 +1448,7 @@ class SettingsGetSettingsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -1460,6 +1462,7 @@ class SettingsGetSettingsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1476,6 +1479,7 @@ class SettingsGetSettingsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/SettingsPaymentMethodLimit.php
+++ b/src/Person/Model/SettingsPaymentMethodLimit.php
@@ -1315,6 +1315,7 @@ class SettingsPaymentMethodLimit implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1327,6 +1328,7 @@ class SettingsPaymentMethodLimit implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -1340,6 +1342,7 @@ class SettingsPaymentMethodLimit implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1356,6 +1359,7 @@ class SettingsPaymentMethodLimit implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/SettingsPaymentMethodLimits.php
+++ b/src/Person/Model/SettingsPaymentMethodLimits.php
@@ -265,6 +265,7 @@ class SettingsPaymentMethodLimits implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class SettingsPaymentMethodLimits implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class SettingsPaymentMethodLimits implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class SettingsPaymentMethodLimits implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/SettingsPaymentMethodSettings.php
+++ b/src/Person/Model/SettingsPaymentMethodSettings.php
@@ -295,6 +295,7 @@ class SettingsPaymentMethodSettings implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class SettingsPaymentMethodSettings implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class SettingsPaymentMethodSettings implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class SettingsPaymentMethodSettings implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/SettingsPaymentMethods.php
+++ b/src/Person/Model/SettingsPaymentMethods.php
@@ -265,6 +265,7 @@ class SettingsPaymentMethods implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class SettingsPaymentMethods implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class SettingsPaymentMethods implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class SettingsPaymentMethods implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/SettingsSignedContracts.php
+++ b/src/Person/Model/SettingsSignedContracts.php
@@ -445,6 +445,7 @@ class SettingsSignedContracts implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -457,6 +458,7 @@ class SettingsSignedContracts implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -470,6 +472,7 @@ class SettingsSignedContracts implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -486,6 +489,7 @@ class SettingsSignedContracts implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/SettingsTacContract.php
+++ b/src/Person/Model/SettingsTacContract.php
@@ -325,6 +325,7 @@ class SettingsTacContract implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class SettingsTacContract implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class SettingsTacContract implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class SettingsTacContract implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/SettingsTransactionFee.php
+++ b/src/Person/Model/SettingsTransactionFee.php
@@ -385,6 +385,7 @@ class SettingsTransactionFee implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class SettingsTransactionFee implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class SettingsTransactionFee implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class SettingsTransactionFee implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsCurrencyStatistics.php
+++ b/src/Person/Model/StatisticsCurrencyStatistics.php
@@ -235,6 +235,7 @@ class StatisticsCurrencyStatistics implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class StatisticsCurrencyStatistics implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class StatisticsCurrencyStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class StatisticsCurrencyStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsCustomerStatistics.php
+++ b/src/Person/Model/StatisticsCustomerStatistics.php
@@ -265,6 +265,7 @@ class StatisticsCustomerStatistics implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class StatisticsCustomerStatistics implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class StatisticsCustomerStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class StatisticsCustomerStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsDnsStatistics.php
+++ b/src/Person/Model/StatisticsDnsStatistics.php
@@ -235,6 +235,7 @@ class StatisticsDnsStatistics implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class StatisticsDnsStatistics implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class StatisticsDnsStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class StatisticsDnsStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsDomainStatistics.php
+++ b/src/Person/Model/StatisticsDomainStatistics.php
@@ -265,6 +265,7 @@ class StatisticsDomainStatistics implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class StatisticsDomainStatistics implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class StatisticsDomainStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class StatisticsDomainStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsDomainStatisticsByStatus.php
+++ b/src/Person/Model/StatisticsDomainStatisticsByStatus.php
@@ -385,6 +385,7 @@ class StatisticsDomainStatisticsByStatus implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class StatisticsDomainStatisticsByStatus implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class StatisticsDomainStatisticsByStatus implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class StatisticsDomainStatisticsByStatus implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsGetStatisticsResponse.php
+++ b/src/Person/Model/StatisticsGetStatisticsResponse.php
@@ -355,6 +355,7 @@ class StatisticsGetStatisticsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class StatisticsGetStatisticsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class StatisticsGetStatisticsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class StatisticsGetStatisticsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsGetStatisticsResponseData.php
+++ b/src/Person/Model/StatisticsGetStatisticsResponseData.php
@@ -415,6 +415,7 @@ class StatisticsGetStatisticsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -427,6 +428,7 @@ class StatisticsGetStatisticsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -440,6 +442,7 @@ class StatisticsGetStatisticsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -456,6 +459,7 @@ class StatisticsGetStatisticsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsLicenseStatistics.php
+++ b/src/Person/Model/StatisticsLicenseStatistics.php
@@ -235,6 +235,7 @@ class StatisticsLicenseStatistics implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class StatisticsLicenseStatistics implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class StatisticsLicenseStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class StatisticsLicenseStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsSpamExpertsStatistics.php
+++ b/src/Person/Model/StatisticsSpamExpertsStatistics.php
@@ -505,6 +505,7 @@ class StatisticsSpamExpertsStatistics implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -517,6 +518,7 @@ class StatisticsSpamExpertsStatistics implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -530,6 +532,7 @@ class StatisticsSpamExpertsStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -546,6 +549,7 @@ class StatisticsSpamExpertsStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsSslStatistics.php
+++ b/src/Person/Model/StatisticsSslStatistics.php
@@ -265,6 +265,7 @@ class StatisticsSslStatistics implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class StatisticsSslStatistics implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class StatisticsSslStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class StatisticsSslStatistics implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Person/Model/StatisticsSslStatisticsByStatus.php
+++ b/src/Person/Model/StatisticsSslStatisticsByStatus.php
@@ -385,6 +385,7 @@ class StatisticsSslStatisticsByStatus implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class StatisticsSslStatisticsByStatus implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class StatisticsSslStatisticsByStatus implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class StatisticsSslStatisticsByStatus implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/ErrorError.php
+++ b/src/SpamExpert/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/ErrorWarning.php
+++ b/src/SpamExpert/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/ResponseBoolResponse.php
+++ b/src/SpamExpert/Model/ResponseBoolResponse.php
@@ -355,6 +355,7 @@ class ResponseBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ResponseBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ResponseBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ResponseBoolResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/ResponseBoolResponseData.php
+++ b/src/SpamExpert/Model/ResponseBoolResponseData.php
@@ -235,6 +235,7 @@ class ResponseBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ResponseBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ResponseBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ResponseBoolResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/SeDomainAliasUpdates.php
+++ b/src/SpamExpert/Model/SeDomainAliasUpdates.php
@@ -265,6 +265,7 @@ class SeDomainAliasUpdates implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class SeDomainAliasUpdates implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class SeDomainAliasUpdates implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class SeDomainAliasUpdates implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/SeDomainCreateDomainRequest.php
+++ b/src/SpamExpert/Model/SeDomainCreateDomainRequest.php
@@ -355,6 +355,7 @@ class SeDomainCreateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class SeDomainCreateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class SeDomainCreateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class SeDomainCreateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/SeDomainDestination.php
+++ b/src/SpamExpert/Model/SeDomainDestination.php
@@ -265,6 +265,7 @@ class SeDomainDestination implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class SeDomainDestination implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class SeDomainDestination implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class SeDomainDestination implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/SeDomainDomain.php
+++ b/src/SpamExpert/Model/SeDomainDomain.php
@@ -595,6 +595,7 @@ class SeDomainDomain implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -607,6 +608,7 @@ class SeDomainDomain implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -620,6 +622,7 @@ class SeDomainDomain implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -636,6 +639,7 @@ class SeDomainDomain implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/SeDomainGetDomainResponse.php
+++ b/src/SpamExpert/Model/SeDomainGetDomainResponse.php
@@ -355,6 +355,7 @@ class SeDomainGetDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class SeDomainGetDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class SeDomainGetDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class SeDomainGetDomainResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/SeDomainProducts.php
+++ b/src/SpamExpert/Model/SeDomainProducts.php
@@ -295,6 +295,7 @@ class SeDomainProducts implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class SeDomainProducts implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class SeDomainProducts implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class SeDomainProducts implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/SeDomainRecords.php
+++ b/src/SpamExpert/Model/SeDomainRecords.php
@@ -295,6 +295,7 @@ class SeDomainRecords implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class SeDomainRecords implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class SeDomainRecords implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class SeDomainRecords implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/SpamExpert/Model/SeDomainUpdateDomainRequest.php
+++ b/src/SpamExpert/Model/SeDomainUpdateDomainRequest.php
@@ -355,6 +355,7 @@ class SeDomainUpdateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class SeDomainUpdateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class SeDomainUpdateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class SeDomainUpdateDomainRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ApproveremailListApproverEmailsResponse.php
+++ b/src/Ssl/Model/ApproveremailListApproverEmailsResponse.php
@@ -355,6 +355,7 @@ class ApproveremailListApproverEmailsResponse implements ModelInterface, ArrayAc
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ApproveremailListApproverEmailsResponse implements ModelInterface, ArrayAc
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ApproveremailListApproverEmailsResponse implements ModelInterface, ArrayAc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ApproveremailListApproverEmailsResponse implements ModelInterface, ArrayAc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ApproveremailListApproverEmailsResponseData.php
+++ b/src/Ssl/Model/ApproveremailListApproverEmailsResponseData.php
@@ -235,6 +235,7 @@ class ApproveremailListApproverEmailsResponseData implements ModelInterface, Arr
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ApproveremailListApproverEmailsResponseData implements ModelInterface, Arr
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ApproveremailListApproverEmailsResponseData implements ModelInterface, Arr
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ApproveremailListApproverEmailsResponseData implements ModelInterface, Arr
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ApproveremailResendApproverEmailRequest.php
+++ b/src/Ssl/Model/ApproveremailResendApproverEmailRequest.php
@@ -235,6 +235,7 @@ class ApproveremailResendApproverEmailRequest implements ModelInterface, ArrayAc
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ApproveremailResendApproverEmailRequest implements ModelInterface, ArrayAc
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ApproveremailResendApproverEmailRequest implements ModelInterface, ArrayAc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ApproveremailResendApproverEmailRequest implements ModelInterface, ArrayAc
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ApproveremailResendApproverEmailResponse.php
+++ b/src/Ssl/Model/ApproveremailResendApproverEmailResponse.php
@@ -355,6 +355,7 @@ class ApproveremailResendApproverEmailResponse implements ModelInterface, ArrayA
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ApproveremailResendApproverEmailResponse implements ModelInterface, ArrayA
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ApproveremailResendApproverEmailResponse implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ApproveremailResendApproverEmailResponse implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ApproveremailResendApproverEmailResponseData.php
+++ b/src/Ssl/Model/ApproveremailResendApproverEmailResponseData.php
@@ -235,6 +235,7 @@ class ApproveremailResendApproverEmailResponseData implements ModelInterface, Ar
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ApproveremailResendApproverEmailResponseData implements ModelInterface, Ar
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ApproveremailResendApproverEmailResponseData implements ModelInterface, Ar
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ApproveremailResendApproverEmailResponseData implements ModelInterface, Ar
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ApproveremailUpdateApproverEmailAddressRequest.php
+++ b/src/Ssl/Model/ApproveremailUpdateApproverEmailAddressRequest.php
@@ -265,6 +265,7 @@ class ApproveremailUpdateApproverEmailAddressRequest implements ModelInterface, 
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ApproveremailUpdateApproverEmailAddressRequest implements ModelInterface, 
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ApproveremailUpdateApproverEmailAddressRequest implements ModelInterface, 
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ApproveremailUpdateApproverEmailAddressRequest implements ModelInterface, 
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ApproveremailUpdateApproverEmailAddressResponse.php
+++ b/src/Ssl/Model/ApproveremailUpdateApproverEmailAddressResponse.php
@@ -355,6 +355,7 @@ class ApproveremailUpdateApproverEmailAddressResponse implements ModelInterface,
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ApproveremailUpdateApproverEmailAddressResponse implements ModelInterface,
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ApproveremailUpdateApproverEmailAddressResponse implements ModelInterface,
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ApproveremailUpdateApproverEmailAddressResponse implements ModelInterface,
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ApproveremailUpdateApproverEmailAddressResponseData.php
+++ b/src/Ssl/Model/ApproveremailUpdateApproverEmailAddressResponseData.php
@@ -235,6 +235,7 @@ class ApproveremailUpdateApproverEmailAddressResponseData implements ModelInterf
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class ApproveremailUpdateApproverEmailAddressResponseData implements ModelInterf
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class ApproveremailUpdateApproverEmailAddressResponseData implements ModelInterf
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class ApproveremailUpdateApproverEmailAddressResponseData implements ModelInterf
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/CsrCreateCsrRequest.php
+++ b/src/Ssl/Model/CsrCreateCsrRequest.php
@@ -535,6 +535,7 @@ class CsrCreateCsrRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -547,6 +548,7 @@ class CsrCreateCsrRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -560,6 +562,7 @@ class CsrCreateCsrRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -576,6 +579,7 @@ class CsrCreateCsrRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/CsrCreateCsrResponse.php
+++ b/src/Ssl/Model/CsrCreateCsrResponse.php
@@ -355,6 +355,7 @@ class CsrCreateCsrResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class CsrCreateCsrResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class CsrCreateCsrResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class CsrCreateCsrResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/CsrCreateCsrResponseData.php
+++ b/src/Ssl/Model/CsrCreateCsrResponseData.php
@@ -385,6 +385,7 @@ class CsrCreateCsrResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class CsrCreateCsrResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class CsrCreateCsrResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class CsrCreateCsrResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/CsrCsrPublicKey.php
+++ b/src/Ssl/Model/CsrCsrPublicKey.php
@@ -265,6 +265,7 @@ class CsrCsrPublicKey implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class CsrCsrPublicKey implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class CsrCsrPublicKey implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class CsrCsrPublicKey implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/CsrCsrSubject.php
+++ b/src/Ssl/Model/CsrCsrSubject.php
@@ -415,6 +415,7 @@ class CsrCsrSubject implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -427,6 +428,7 @@ class CsrCsrSubject implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -440,6 +442,7 @@ class CsrCsrSubject implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -456,6 +459,7 @@ class CsrCsrSubject implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/CsrDecodeCsrRequest.php
+++ b/src/Ssl/Model/CsrDecodeCsrRequest.php
@@ -235,6 +235,7 @@ class CsrDecodeCsrRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class CsrDecodeCsrRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class CsrDecodeCsrRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class CsrDecodeCsrRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/CsrDecodeCsrResponse.php
+++ b/src/Ssl/Model/CsrDecodeCsrResponse.php
@@ -355,6 +355,7 @@ class CsrDecodeCsrResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class CsrDecodeCsrResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class CsrDecodeCsrResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class CsrDecodeCsrResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/CsrDecodeCsrResponseData.php
+++ b/src/Ssl/Model/CsrDecodeCsrResponseData.php
@@ -355,6 +355,7 @@ class CsrDecodeCsrResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class CsrDecodeCsrResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class CsrDecodeCsrResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class CsrDecodeCsrResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ErrorError.php
+++ b/src/Ssl/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ErrorWarning.php
+++ b/src/Ssl/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderCancelOrderRequest.php
+++ b/src/Ssl/Model/OrderCancelOrderRequest.php
@@ -235,6 +235,7 @@ class OrderCancelOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class OrderCancelOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class OrderCancelOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class OrderCancelOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderCancelOrderResponse.php
+++ b/src/Ssl/Model/OrderCancelOrderResponse.php
@@ -355,6 +355,7 @@ class OrderCancelOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class OrderCancelOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class OrderCancelOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class OrderCancelOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderCancelOrderResponseData.php
+++ b/src/Ssl/Model/OrderCancelOrderResponseData.php
@@ -235,6 +235,7 @@ class OrderCancelOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class OrderCancelOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class OrderCancelOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class OrderCancelOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderCreateOrderRequest.php
+++ b/src/Ssl/Model/OrderCreateOrderRequest.php
@@ -655,6 +655,7 @@ class OrderCreateOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -667,6 +668,7 @@ class OrderCreateOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -680,6 +682,7 @@ class OrderCreateOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -696,6 +699,7 @@ class OrderCreateOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderCreateOrderResponse.php
+++ b/src/Ssl/Model/OrderCreateOrderResponse.php
@@ -355,6 +355,7 @@ class OrderCreateOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class OrderCreateOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class OrderCreateOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class OrderCreateOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderCreateOrderResponseData.php
+++ b/src/Ssl/Model/OrderCreateOrderResponseData.php
@@ -235,6 +235,7 @@ class OrderCreateOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class OrderCreateOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class OrderCreateOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class OrderCreateOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderGetOrderResponse.php
+++ b/src/Ssl/Model/OrderGetOrderResponse.php
@@ -355,6 +355,7 @@ class OrderGetOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class OrderGetOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class OrderGetOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class OrderGetOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderListOrdersRequestOrderBy.php
+++ b/src/Ssl/Model/OrderListOrdersRequestOrderBy.php
@@ -385,6 +385,7 @@ class OrderListOrdersRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class OrderListOrdersRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class OrderListOrdersRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class OrderListOrdersRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderListOrdersResponse.php
+++ b/src/Ssl/Model/OrderListOrdersResponse.php
@@ -355,6 +355,7 @@ class OrderListOrdersResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class OrderListOrdersResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class OrderListOrdersResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class OrderListOrdersResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderListOrdersResponseData.php
+++ b/src/Ssl/Model/OrderListOrdersResponseData.php
@@ -265,6 +265,7 @@ class OrderListOrdersResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class OrderListOrdersResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class OrderListOrdersResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class OrderListOrdersResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderReissueOrderRequest.php
+++ b/src/Ssl/Model/OrderReissueOrderRequest.php
@@ -475,6 +475,7 @@ class OrderReissueOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -487,6 +488,7 @@ class OrderReissueOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -500,6 +502,7 @@ class OrderReissueOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -516,6 +519,7 @@ class OrderReissueOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderReissueOrderResponse.php
+++ b/src/Ssl/Model/OrderReissueOrderResponse.php
@@ -355,6 +355,7 @@ class OrderReissueOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class OrderReissueOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class OrderReissueOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class OrderReissueOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderReissueOrderResponseData.php
+++ b/src/Ssl/Model/OrderReissueOrderResponseData.php
@@ -235,6 +235,7 @@ class OrderReissueOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class OrderReissueOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class OrderReissueOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class OrderReissueOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderRenewOrderRequest.php
+++ b/src/Ssl/Model/OrderRenewOrderRequest.php
@@ -265,6 +265,7 @@ class OrderRenewOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class OrderRenewOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class OrderRenewOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class OrderRenewOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderRenewOrderResponse.php
+++ b/src/Ssl/Model/OrderRenewOrderResponse.php
@@ -355,6 +355,7 @@ class OrderRenewOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class OrderRenewOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class OrderRenewOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class OrderRenewOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderRenewOrderResponseData.php
+++ b/src/Ssl/Model/OrderRenewOrderResponseData.php
@@ -235,6 +235,7 @@ class OrderRenewOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class OrderRenewOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class OrderRenewOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class OrderRenewOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderSslOrder.php
+++ b/src/Ssl/Model/OrderSslOrder.php
@@ -1225,6 +1225,7 @@ class OrderSslOrder implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1237,6 +1238,7 @@ class OrderSslOrder implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -1250,6 +1252,7 @@ class OrderSslOrder implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1266,6 +1269,7 @@ class OrderSslOrder implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderSslOrderAdditionalData.php
+++ b/src/Ssl/Model/OrderSslOrderAdditionalData.php
@@ -625,6 +625,7 @@ class OrderSslOrderAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -637,6 +638,7 @@ class OrderSslOrderAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -650,6 +652,7 @@ class OrderSslOrderAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -666,6 +669,7 @@ class OrderSslOrderAdditionalData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderSslOrderDomainValidationMethods.php
+++ b/src/Ssl/Model/OrderSslOrderDomainValidationMethods.php
@@ -265,6 +265,7 @@ class OrderSslOrderDomainValidationMethods implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class OrderSslOrderDomainValidationMethods implements ModelInterface, ArrayAcces
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class OrderSslOrderDomainValidationMethods implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class OrderSslOrderDomainValidationMethods implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderSslOrderDomainValidationStatuses.php
+++ b/src/Ssl/Model/OrderSslOrderDomainValidationStatuses.php
@@ -325,6 +325,7 @@ class OrderSslOrderDomainValidationStatuses implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class OrderSslOrderDomainValidationStatuses implements ModelInterface, ArrayAcce
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class OrderSslOrderDomainValidationStatuses implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class OrderSslOrderDomainValidationStatuses implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderSslOrderOptions.php
+++ b/src/Ssl/Model/OrderSslOrderOptions.php
@@ -235,6 +235,7 @@ class OrderSslOrderOptions implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class OrderSslOrderOptions implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class OrderSslOrderOptions implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class OrderSslOrderOptions implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderUpdateOrderRequest.php
+++ b/src/Ssl/Model/OrderUpdateOrderRequest.php
@@ -565,6 +565,7 @@ class OrderUpdateOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -577,6 +578,7 @@ class OrderUpdateOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -590,6 +592,7 @@ class OrderUpdateOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -606,6 +609,7 @@ class OrderUpdateOrderRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderUpdateOrderResponse.php
+++ b/src/Ssl/Model/OrderUpdateOrderResponse.php
@@ -355,6 +355,7 @@ class OrderUpdateOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class OrderUpdateOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class OrderUpdateOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class OrderUpdateOrderResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OrderUpdateOrderResponseData.php
+++ b/src/Ssl/Model/OrderUpdateOrderResponseData.php
@@ -235,6 +235,7 @@ class OrderUpdateOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class OrderUpdateOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class OrderUpdateOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class OrderUpdateOrderResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OtptokenCreateOtpTokenRequest.php
+++ b/src/Ssl/Model/OtptokenCreateOtpTokenRequest.php
@@ -235,6 +235,7 @@ class OtptokenCreateOtpTokenRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -247,6 +248,7 @@ class OtptokenCreateOtpTokenRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -260,6 +262,7 @@ class OtptokenCreateOtpTokenRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -276,6 +279,7 @@ class OtptokenCreateOtpTokenRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OtptokenCreateOtpTokenResponse.php
+++ b/src/Ssl/Model/OtptokenCreateOtpTokenResponse.php
@@ -355,6 +355,7 @@ class OtptokenCreateOtpTokenResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class OtptokenCreateOtpTokenResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class OtptokenCreateOtpTokenResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class OtptokenCreateOtpTokenResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/OtptokenCreateOtpTokenResponseData.php
+++ b/src/Ssl/Model/OtptokenCreateOtpTokenResponseData.php
@@ -295,6 +295,7 @@ class OtptokenCreateOtpTokenResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class OtptokenCreateOtpTokenResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class OtptokenCreateOtpTokenResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class OtptokenCreateOtpTokenResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductGetProductResponse.php
+++ b/src/Ssl/Model/ProductGetProductResponse.php
@@ -355,6 +355,7 @@ class ProductGetProductResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ProductGetProductResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ProductGetProductResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ProductGetProductResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductListProductsRequestOrderBy.php
+++ b/src/Ssl/Model/ProductListProductsRequestOrderBy.php
@@ -385,6 +385,7 @@ class ProductListProductsRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,6 +398,7 @@ class ProductListProductsRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -410,6 +412,7 @@ class ProductListProductsRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,6 +429,7 @@ class ProductListProductsRequestOrderBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductListProductsResponse.php
+++ b/src/Ssl/Model/ProductListProductsResponse.php
@@ -355,6 +355,7 @@ class ProductListProductsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class ProductListProductsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class ProductListProductsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class ProductListProductsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductListProductsResponseData.php
+++ b/src/Ssl/Model/ProductListProductsResponseData.php
@@ -265,6 +265,7 @@ class ProductListProductsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ProductListProductsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ProductListProductsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ProductListProductsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductSslProduct.php
+++ b/src/Ssl/Model/ProductSslProduct.php
@@ -1045,6 +1045,7 @@ class ProductSslProduct implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1057,6 +1058,7 @@ class ProductSslProduct implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -1070,6 +1072,7 @@ class ProductSslProduct implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1086,6 +1089,7 @@ class ProductSslProduct implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductSslProductLevelPrices.php
+++ b/src/Ssl/Model/ProductSslProductLevelPrices.php
@@ -295,6 +295,7 @@ class ProductSslProductLevelPrices implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ProductSslProductLevelPrices implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ProductSslProductLevelPrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ProductSslProductLevelPrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductSslProductPrice.php
+++ b/src/Ssl/Model/ProductSslProductPrice.php
@@ -265,6 +265,7 @@ class ProductSslProductPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ProductSslProductPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ProductSslProductPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ProductSslProductPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductSslProductPriceGroup.php
+++ b/src/Ssl/Model/ProductSslProductPriceGroup.php
@@ -265,6 +265,7 @@ class ProductSslProductPriceGroup implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ProductSslProductPriceGroup implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ProductSslProductPriceGroup implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ProductSslProductPriceGroup implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductSslProductPrices.php
+++ b/src/Ssl/Model/ProductSslProductPrices.php
@@ -325,6 +325,7 @@ class ProductSslProductPrices implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,6 +338,7 @@ class ProductSslProductPrices implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -350,6 +352,7 @@ class ProductSslProductPrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,6 +369,7 @@ class ProductSslProductPrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductSslProductReseller.php
+++ b/src/Ssl/Model/ProductSslProductReseller.php
@@ -265,6 +265,7 @@ class ProductSslProductReseller implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ProductSslProductReseller implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ProductSslProductReseller implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ProductSslProductReseller implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductSslProductSupportedSoftware.php
+++ b/src/Ssl/Model/ProductSslProductSupportedSoftware.php
@@ -265,6 +265,7 @@ class ProductSslProductSupportedSoftware implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ProductSslProductSupportedSoftware implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ProductSslProductSupportedSoftware implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ProductSslProductSupportedSoftware implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Ssl/Model/ProductSslProductWarranty.php
+++ b/src/Ssl/Model/ProductSslProductWarranty.php
@@ -265,6 +265,7 @@ class ProductSslProductWarranty implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class ProductSslProductWarranty implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class ProductSslProductWarranty implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class ProductSslProductWarranty implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/ErrorError.php
+++ b/src/Tld/Model/ErrorError.php
@@ -295,6 +295,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/ErrorWarning.php
+++ b/src/Tld/Model/ErrorWarning.php
@@ -295,6 +295,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class ErrorWarning implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldApplicationMode.php
+++ b/src/Tld/Model/TldApplicationMode.php
@@ -265,6 +265,7 @@ class TldApplicationMode implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TldApplicationMode implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TldApplicationMode implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TldApplicationMode implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldDescription.php
+++ b/src/Tld/Model/TldDescription.php
@@ -265,6 +265,7 @@ class TldDescription implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TldDescription implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TldDescription implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TldDescription implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldGetTldResponse.php
+++ b/src/Tld/Model/TldGetTldResponse.php
@@ -355,6 +355,7 @@ class TldGetTldResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class TldGetTldResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class TldGetTldResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class TldGetTldResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldIdnScript.php
+++ b/src/Tld/Model/TldIdnScript.php
@@ -265,6 +265,7 @@ class TldIdnScript implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TldIdnScript implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TldIdnScript implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TldIdnScript implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldLevelPrice.php
+++ b/src/Tld/Model/TldLevelPrice.php
@@ -265,6 +265,7 @@ class TldLevelPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TldLevelPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TldLevelPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TldLevelPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldListTldsResponse.php
+++ b/src/Tld/Model/TldListTldsResponse.php
@@ -355,6 +355,7 @@ class TldListTldsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -367,6 +368,7 @@ class TldListTldsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -380,6 +382,7 @@ class TldListTldsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,6 +399,7 @@ class TldListTldsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldListTldsResponseData.php
+++ b/src/Tld/Model/TldListTldsResponseData.php
@@ -265,6 +265,7 @@ class TldListTldsResponseData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TldListTldsResponseData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TldListTldsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TldListTldsResponseData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldPrice.php
+++ b/src/Tld/Model/TldPrice.php
@@ -265,6 +265,7 @@ class TldPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TldPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TldPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TldPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldPriceInCurrency.php
+++ b/src/Tld/Model/TldPriceInCurrency.php
@@ -265,6 +265,7 @@ class TldPriceInCurrency implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -277,6 +278,7 @@ class TldPriceInCurrency implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -290,6 +292,7 @@ class TldPriceInCurrency implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -306,6 +309,7 @@ class TldPriceInCurrency implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldPriceWithPromoInfo.php
+++ b/src/Tld/Model/TldPriceWithPromoInfo.php
@@ -295,6 +295,7 @@ class TldPriceWithPromoInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class TldPriceWithPromoInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class TldPriceWithPromoInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class TldPriceWithPromoInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldPrices.php
+++ b/src/Tld/Model/TldPrices.php
@@ -565,6 +565,7 @@ class TldPrices implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -577,6 +578,7 @@ class TldPrices implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -590,6 +592,7 @@ class TldPrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -606,6 +609,7 @@ class TldPrices implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldPromoDetails.php
+++ b/src/Tld/Model/TldPromoDetails.php
@@ -295,6 +295,7 @@ class TldPromoDetails implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -307,6 +308,7 @@ class TldPromoDetails implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -320,6 +322,7 @@ class TldPromoDetails implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -336,6 +339,7 @@ class TldPromoDetails implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/Tld/Model/TldTld.php
+++ b/src/Tld/Model/TldTld.php
@@ -1255,6 +1255,7 @@ class TldTld implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1267,6 +1268,7 @@ class TldTld implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -1280,6 +1282,7 @@ class TldTld implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1296,6 +1299,7 @@ class TldTld implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);


### PR DESCRIPTION
Add attribute to class methods to omit the deprecation notice in PHP 8.1 

See https://php.watch/versions/8.1/ReturnTypeWillChange.